### PR TITLE
add paddleclas link

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Note: <sup>*</sup> indicates multi-scale testing.
 
 (`Note please report accuracy numbers and provide trained models in your new repository to facilitate others to get sense of correctness and model behavior`)
 
+[06/29/2021] Swin-Transformer in PaddleClas and inference based on whl package: [https://github.com/PaddlePaddle/PaddleClas](https://github.com/PaddlePaddle/PaddleClas)
+
 [04/14/2021] Swin for RetinaNet in Detectron: https://github.com/xiaohu2015/SwinT_detectron2.
 
 [04/16/2021] Included in a famous model zoo: https://github.com/rwightman/pytorch-image-models.


### PR DESCRIPTION
Att, for more details of swin-transformer using PaddlePaddle, please refer to [link](https://github.com/PaddlePaddle/PaddleClas/blob/release%2F2.2/docs/zh_CN/models/SwinTransformer.md)

![image](https://user-images.githubusercontent.com/14270174/123728284-98e16f80-d8c5-11eb-9a50-cba6bec43449.png)
