### PR TITLE
Update README.md to include TensorFlow implementation of Swin Transformers V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ Note: <sup>*</sup> indicates multi-scale testing.
 
 (`Note please report accuracy numbers and provide trained models in your new repository to facilitate others to get sense of correctness and model behavior`)
 
+[05/12/2022] Swin Transformers (V1) implemented in TensorFlow with the pre-trained parameters ported into them. Find the implementation,
+TensorFlow weights, code example here in [this repository](https://github.com/sayakpaul/swin-transformers-tf/).
+
 [04/06/2022] Swin Transformer for Audio Classification: [Hierarchical Token Semantic Audio Transformer](https://github.com/RetroCirce/HTS-Audio-Transformer).
 
 [12/21/2021] Swin Transformer for StyleGAN: [StyleSwin](https://github.com/microsoft/StyleSwin)


### PR DESCRIPTION
I have verified the [results](https://github.com/sayakpaul/swin-transformers-tf/) (code [here](https://github.com/sayakpaul/swin-transformers-tf/tree/main/in1k-eval)) and I guess they confirm the implementation correctness:

![image](https://user-images.githubusercontent.com/22957388/168027715-cc337231-26d5-43a2-ab9b-51b45b31966a.png)

@zeliu98 @ancientmooner 

