### PR TITLE
add swin2sr (ECCVW 2022) cross reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ Note: <sup>*</sup> indicates multi-scale testing.
 
 (`Note please report accuracy numbers and provide trained models in your new repository to facilitate others to get sense of correctness and model behavior`)
 
+[01/10/2022] SwinV2 Transformer for Compressed Image Super-Resolution and Restoration: [Swin2SR](https://github.com/mv-lab/swin2sr) at AIM, ECCV 2022
+
 [06/30/2022] Swin Transformers (V1) inference implemented in FasterTransformer: [FasterTransformer](https://github.com/NVIDIA/FasterTransformer/blob/main/docs/swin_guide.md)
 
 [05/12/2022] Swin Transformers (V1) implemented in TensorFlow with the pre-trained parameters ported into them. Find the implementation,


### PR DESCRIPTION
[Swin2SR: SwinV2 Transformer for Compressed Image Super-Resolution and Restoration](https://arxiv.org/abs/2209.11345) at AIM, ECCV 2022. Code and demos available. 

We explore the new Swin Transformer V2 as a possible improvement for the famous [SwinIR](https://github.com/JingyunLiang/SwinIR) by [Jingyun Liang](https://jingyunliang.github.io/), and evaluate its capabilities on new problems such as compressed input resolution.